### PR TITLE
Replace docker wait by depends_on -> service_healthy

### DIFF
--- a/build/gen-conf/Dockerfile
+++ b/build/gen-conf/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+RUN apk add --no-cache bash
+ENTRYPOINT ["/bin/bash"]

--- a/build/redmine/Dockerfile
+++ b/build/redmine/Dockerfile
@@ -6,6 +6,8 @@ RUN true \
         && git clone https://github.com/alphanodes/additionals.git plugins/additionals \
         && git clone https://github.com/alphanodes/redmine_saml.git plugins/redmine_saml \
         && git clone https://github.com/farend/redmine_message_customize.git plugins/redmine_message_customize\
+        && apt update \
+        && apt install -y curl \
         && true
 
 RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,15 +31,13 @@ services:
   # and also specifying the directory as good for the server to look inside
   # semanage fcontext -a -t httpd_sys_content_t "/srv/static/next(/.*)?"
   # restorecon -Rv /srv/static/next
-  next:
+  next-common: &next-common
     image: nextcloud:29-fpm
     volumes:
       - ./data/next/data/html:/var/www/html:z
       - ./data/next/data/html:/srv/static/next:z
       - ./data/next/data/data:/var/www/html/data:Z
-    depends_on:
-      - db-next
-      - openldap
+      - ./provision.sh:/usr/local/lib/provision.sh
     environment:
       - POSTGRES_PASSWORD=$NEXT_POSTGRES_PASSWORD
       - POSTGRES_DB=$NEXT_POSTGRES_DB
@@ -68,6 +66,27 @@ services:
       - next-backend
       - ldap-backend
 
+  next:
+    <<: *next-common
+    depends_on:
+      db-next:
+        condition: service_healthy
+      # TODO this might belong to next-init.depends_on
+      ldap-config-acl:
+        condition: service_completed_successfully
+
+  next-init:
+    <<: *next-common
+    entrypoint: >
+      bash -c '
+        . /usr/local/lib/provision.sh
+        configure_nextcloud
+        configure_nextcloud_ldap
+        '
+    depends_on:
+      next:
+        condition: service_healthy
+
   gateway:
     image: nginx:stable
     ports:
@@ -81,12 +100,18 @@ services:
       - ./data/next/data/html:/srv/static/next:ro,z
       - ./data/gateway/conf.d:/etc/nginx/conf.d:ro,Z
     depends_on:
-      - bureau
-      - keycloak
-      - next
-      - phpldapadmin
-      - redmine
-      - rocketchat
+      bureau:
+        condition: service_healthy
+      keycloak-config:
+        condition: service_completed_successfully
+      next:
+        condition: service_healthy
+      phpldapadmin:
+        condition: service_started
+      redmine:
+        condition: service_healthy
+      rocketchat:
+        condition: service_started
     deploy:
       resources:
         limits:
@@ -99,6 +124,7 @@ services:
       - ldap-backend
       - rocket-backend
       - keycloak-backend
+      - redmine-backend
 
   mongo-rocket:
     image: mongo:6.0
@@ -127,6 +153,25 @@ services:
         aliases:
           - db
 
+  mongo-init-rs:
+    image: mongo:6
+    depends_on:
+      mongo-rocket:
+        condition: service_healthy
+    entrypoint: >
+      bash -c '
+      until mongosh --host mongo-rocket --quiet --eval "rs.status().ok" ||
+            mongosh --host mongo-rocket --quiet --eval "rs.initiate({
+                _id: \"rs0\",
+                members: [{ _id: 0, host: \"mongo-rocket:27017\" }]
+            }).ok
+      "; do
+        sleep 2
+      done
+      '
+    networks:
+      - rocket-backend
+
   rocketchat:
     image: rocket.chat:6.0
     volumes:
@@ -144,8 +189,10 @@ services:
       - OVERWRITE_SETTING_Show_Setup_Wizard=completed
     command: bash -c 'for i in `seq 1 30`; do node main.js && s=$$? && break || s=$$?; echo "Tried $$i times. Waiting 5 secs..."; sleep 5; done; (exit $$s)'
     depends_on:
-      - mongo-rocket
-      - openldap
+      ldap-config-acl:
+        condition: service_completed_successfully
+      mongo-init-rs:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -177,6 +224,7 @@ services:
     volumes:
       - ./data/ldap/data:/var/lib/ldap:Z
       - ./data/ldap/slapd.d:/etc/ldap/slapd.d:Z
+      - ./ldap-health-check.sh:/usr/local/bin/ldap-health-check.sh
     deploy:
       resources:
         limits:
@@ -184,10 +232,25 @@ services:
           memory: 80M
         reservations:
           memory: 50M
+    healthcheck:
+      test: [ "CMD", "/usr/local/bin/ldap-health-check.sh" ]
     networks:
       ldap-backend:
         aliases:
           - ldap
+
+  ldap-config-acl:
+    image: entint/openldap
+    volumes:
+      - ./provision.sh:/usr/local/lib/provision.sh
+    depends_on:
+      openldap:
+        condition: service_healthy
+    entrypoint: >
+      bash -c '
+      . /usr/local/lib/provision.sh
+      configure_ldap_acl
+      '
 
   phpldapadmin:
     image: osixia/phpldapadmin
@@ -195,7 +258,8 @@ services:
       PHPLDAPADMIN_LDAP_HOSTS: "openldap"
       PHPLDAPADMIN_HTTPS=false:
     depends_on:
-      - openldap
+      ldap-config-acl:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -253,8 +317,10 @@ services:
       - LDAP_READER_PASSWORD=$LDAP_READER_PASSWORD
 
     depends_on:
-      - db-keycloak
-      - openldap
+      db-keycloak:
+        condition: service_healthy
+      ldap-config-acl:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -271,8 +337,28 @@ services:
       - ldap-backend
       - keycloak-backend
 
+  keycloak-config:
+    image: entint/keycloak
+    volumes:
+      - ./provision.sh:/usr/local/lib/provision.sh
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    entrypoint: >
+      bash -c '
+      . /usr/local/lib/provision.sh
+      configure_keycloak_next
+      configure_keycloak_bureau
+      configure_keycloak_ldap
+      configure_keycloak_rocketchat
+      configure_keycloak_redmine
+      '
+
   bureau:
     image: entint/bureau
+    build:
+      # TODO the same as below
+      context: ../../bureau
     depends_on:
       - rocketchat
       - phpldapadmin
@@ -296,6 +382,9 @@ services:
       - ./data/bureau/env:/app/.env:Z
       - ./data/bureau/ldap.ini:/app/ldap.ini:Z
       - ./data/bureau/settings.json:/app/saml/settings.json:Z
+      # TODO bureau should be submodule of intranet or vice versa.
+      # ../../bureau/bureau breaks when the repo is in unexpected folder.
+      - ../../bureau/bureau:/app/bureau:Z
     security_opt:
       - "seccomp=unconfined"
     healthcheck:
@@ -309,14 +398,31 @@ services:
       - next-backend
       - rocket-backend
 
+  redmine-gen-samlconf:
+    build:
+      context: build/gen-conf
+    volumes:
+      - ./provision.sh:/usr/local/lib/provision.sh
+      - ./data/redmine/config:/redmine-saml-config
+    entrypoint: >
+      bash -c '
+      . /usr/local/lib/provision.sh
+      configure_redmine_saml > /redmine-saml-config/saml.rb
+      '
 
   redmine:
     image: entint/redmine
     build:
       context: build/redmine
+    entrypoint: ["/usr/local/bin/redmine-entrypoint.sh"]
+    command: ["rails", "server", "-b", "0.0.0.0"]
     depends_on:
-      - openldap
-      - db-redmine
+      ldap-config-acl:
+        condition: service_completed_successfully
+      redmine-gen-samlconf:
+        condition: service_completed_successfully
+      db-redmine:
+        condition: service_healthy
     environment:
       - REDMINE_DB_POSTGRES=db
       - REDMINE_DB_USERNAME=$REDMINE_POSTGRES_USER
@@ -326,9 +432,17 @@ services:
       - SECRET_KEY_BASE=$REDMINE_SECRET
     volumes:
       - ./data/redmine/files:/usr/src/redmine/files:Z
-      - ./data/redmine/saml.rb:/usr/src/redmine/config/initializers/saml.rb:Z
+      - ./data/redmine/config/saml.rb:/usr/src/redmine/config/initializers/saml.rb:Z
+      - ./redmine-entrypoint.sh:/usr/local/bin/redmine-entrypoint.sh
     security_opt:
       - "seccomp=unconfined"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
     networks:
       - redmine-backend
       - ldap-backend

--- a/ldap-health-check.sh
+++ b/ldap-health-check.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. provision.sh
+ldapwhoami -H ldap://localhost:389 -D "$ADMIN_DN" -w "$ADMIN_PASSWORD"

--- a/provision.sh
+++ b/provision.sh
@@ -24,6 +24,7 @@ SMTP_HOSTNAME=smtp.$MAIL_HOST
 LOCAL_SETUP="${LOCAL_SETUP:-no}"
 
 KCADM_PATH=/opt/keycloak/bin/kcadm.sh
+KCADM_SERVER="keycloak:1184"
 # yes if we are testing things locally, i.e. without a real domain
 if test "$DOMAINNAME" = localhost; then
 	LOCAL_SETUP=yes
@@ -431,22 +432,16 @@ function bureau_exec_flask {
 
 
 # Useful for indirect configuration using bash and env vars
-function keycloak_exec {
-	docker-compose exec keycloak "$@"
+function run_kcadm {
+	"$KCADM_PATH" --server "$KCADM_SERVER" "$@"
 }
-
-
-function keycloak_exec_kcadm {
-	keycloak_exec "$KCADM_PATH" "$@"
-}
-
 
 # $1: Client name
 # $2: Client ID
 # Prints the internal client ID
 function keycloak_exec_kcadm_new_saml_client {
 	local _id=$2 _name=$1
-	keycloak_exec_kcadm create clients -r master -s "clientId=$_id" -s protocol=saml -s enabled=true -s "name=$_name" -s 'defaultClientScopes=[ ]'
+	run_kcadm create clients -r master -s "clientId=$_id" -s protocol=saml -s enabled=true -s "name=$_name" -s 'defaultClientScopes=[ ]'
 	internal_client_id=$(_keycloak_client_id "$_id")
 	printf '%s' "$internal_client_id"
 }
@@ -458,7 +453,7 @@ function keycloak_add_mappers_to_client {
 	local _id="$1"
 	shift
 	for stuff in "$@"; do
-		keycloak_exec_kcadm create "clients/$_id/protocol-mappers/models" \
+		run_kcadm create "clients/$_id/protocol-mappers/models" \
 			-s name="$stuff" \
 			-s protocol=saml \
 			-s protocolMapper=saml-user-attribute-mapper \
@@ -474,8 +469,8 @@ function keycloak_add_mappers_to_client {
 # $1: Client Name
 function _keycloak_list_mappers {
 	_keycloak_login
-	internal_client_id=$(keycloak_exec_kcadm get clients | jq -M --raw-output ".[] | select(.name == \"$1\").id")
-	keycloak_exec_kcadm get "clients/$internal_client_id/protocol-mappers/models"
+	internal_client_id=$(run_kcadm get clients | jq -M --raw-output ".[] | select(.name == \"$1\").id")
+	run_kcadm get "clients/$internal_client_id/protocol-mappers/models"
 }
 
 
@@ -579,7 +574,7 @@ function configure_nextcloud_saml_certs {
 
 
 function _keycloak_login {
-	keycloak_exec_kcadm config credentials --server http://localhost:8080 --realm master --user "$ADMIN_USER" --password "$ADMIN_PASSWORD" &> /dev/null
+	run_kcadm config credentials --server http://localhost:8080 --realm master --user "$ADMIN_USER" --password "$ADMIN_PASSWORD" &> /dev/null
 }
 
 
@@ -592,13 +587,13 @@ function keycloak_update_client {
 	for arg in "$@"; do
 		_args+=(-s "$arg")
 	done
-	keycloak_exec_kcadm update "clients/$_client_id" --realm master "${_args[@]}"
+	run_kcadm update "clients/$_client_id" --realm master "${_args[@]}"
 }
 
 
 # $1: Literal Client ID URL
 function _keycloak_client_id {
-	printf "%s" "$(keycloak_exec_kcadm get clients --realm master --server http://localhost:8080 -q "clientId=$1" -F id | jq -M --raw-output '.[0].id')"
+	printf "%s" "$(run_kcadm get clients --realm master --server http://localhost:8080 -q "clientId=$1" -F id | jq -M --raw-output '.[0].id')"
 }
 
 
@@ -652,26 +647,26 @@ function _keycloak_update_ldap_component {
 	local value
 	for key in "${!KEYCLOAK_LDAP_CONFIGURATION[@]}"; do
 		value="${KEYCLOAK_LDAP_CONFIGURATION[$key]}"
-		keycloak_exec_kcadm update "components/$1" -s "config.$key=[$value]"
+		run_kcadm update "components/$1" -s "config.$key=[$value]"
 	done
 }
 
 
 function configure_keycloak_ldap {
 	_keycloak_login
-	local ldap_federation_exists=$(keycloak_exec_kcadm get components -r master | jq -r '.[] | select(.providerType=="org.keycloak.storage.UserStorageProvider") | select(.providerId=="ldap") | length > 0')
+	local ldap_federation_exists=$(run_kcadm get components -r master | jq -r '.[] | select(.providerType=="org.keycloak.storage.UserStorageProvider") | select(.providerId=="ldap") | length > 0')
 	if test "$ldap_federation_exists" != true; then
-		keycloak_exec_kcadm create components -r master -s name="ldap" -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s 'config.enabled=["true"]' -s 'config.editMode=["READ_ONLY"]'
+		run_kcadm create components -r master -s name="ldap" -s providerId=ldap -s providerType=org.keycloak.storage.UserStorageProvider -s 'config.enabled=["true"]' -s 'config.editMode=["READ_ONLY"]'
 	fi
-	internal_component_id=$(keycloak_exec_kcadm get components -r master | jq -r '.[] | select(.providerType=="org.keycloak.storage.UserStorageProvider") | select(.providerId=="ldap").id')
+	internal_component_id=$(run_kcadm get components -r master | jq -r '.[] | select(.providerType=="org.keycloak.storage.UserStorageProvider") | select(.providerId=="ldap").id')
 	_keycloak_update_ldap_component "$internal_component_id"
-	keycloak_exec bash -c "$KCADM_PATH update components/$internal_component_id -s config.bindCredential=[\\\"\$LDAP_READER_PASSWORD\\\"]"
+	run_kcadm "$KCADM_PATH" update "components/$internal_component_id" -s "config.bindCredential=[\\\"\$LDAP_READER_PASSWORD\\\"]"
 }
 
 
 function get_idp_cert {
 	# keycloak_realm_cert=$(keycloak_exec_kcadm get realms/master/keys -F 'keys(certificate)' | jq -M --raw-output 'flatten|add.certificate')
-	keycloak_realm_cert=$(keycloak_exec_kcadm get realms/master/keys | jq -M --raw-output '.keys[] | select(.use == "SIG") | select(.type == "RSA").certificate')
+	keycloak_realm_cert=$(run_kcadm get realms/master/keys | jq -M --raw-output '.keys[] | select(.use == "SIG") | select(.type == "RSA").certificate')
 	inline_idp_cert="-----BEGIN CERTIFICATE-----\n${keycloak_realm_cert}\n-----END CERTIFICATE-----\n"
 	printf -- "$inline_idp_cert"
 }
@@ -782,9 +777,8 @@ function prune_mongo_db {
 }
 
 
-# $1: Ldif as string
 function ldap_modify {
-	docker-compose exec -T openldap ldapmodify -Q -Y EXTERNAL -H ldapi:///
+        ldapmodify -H ldap://openldap:389 -w "$ADMIN_PASSWORD" -D "$ADMIN_DN"
 }
 
 

--- a/redmine-entrypoint.sh
+++ b/redmine-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+chown -R redmine:redmine /home/redmine/.bundle || true
+exec /docker-entrypoint.sh "$@"


### PR DESCRIPTION
**The original task:**
  Replace the `docker wait` in `start.sh` with dependencies in `docker-compose.yml`.

**This led to:**
  Replacing the `start.sh` by `docker compose up` on `docker-compose.yml` with explicit dependencies and configuration functions running in one-shot containers.

**Pros:**
  * More efficient startup: non-dependent services can start in parallel.
  * Explicit and precise specification of service dependencies.
  * Fully declarative and reproducible setup (`docker compose up` is sufficient).
  
**Cons:**
  * Configuration is spread across a large `docker-compose.yml` instead of being centralized in one relatively short start script.
  * The Compose setup becomes more complex due to additional one-shot init/config services.