### PR TITLE
Fix Bundler cache ownership for redmine user

### DIFF
--- a/build/redmine/Dockerfile
+++ b/build/redmine/Dockerfile
@@ -9,3 +9,5 @@ RUN true \
         && true
 
 RUN bundle install
+RUN mkdir -p /home/redmine/.bundle \
+    && chown -R redmine:redmine /home/redmine


### PR DESCRIPTION
This PR fixes Redmine startup that was failing with:
```
There was an error while trying to write to
`/home/redmine/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/versions.30.tmp`.
It is likely that you need to grant write permissions for that path.
```