### PR TITLE
Replace commands `docker-compose` by `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # intranet
 The True Enterprisey Intranet Setup
 
-This project contains support scripts that assist in deployment of an intranet setup based on docker-compose and podman.
+This project contains support scripts that assist in deployment of an intranet setup based on docker compose and podman.
 Namely:
 
 - Installation and enablement of Nextcloud apps.
@@ -26,6 +26,6 @@ Namely:
 
 ## How to use
 
-Create a file .env based on .env.example, so the docker-compose can populate variables from it.
+Create a file .env based on .env.example, so the docker compose can populate variables from it.
 You may have to define a bunch of DB-app passwords in there.
 The admin password can be also changed, but you will have to repeat the change in the `start.sh` file too, as both containers and provisioning scripts need to know it.

--- a/cleanup_data.sh
+++ b/cleanup_data.sh
@@ -1,3 +1,3 @@
-docker-compose rm -s -f openldap keycloak db-keycloak next db-next db-redmine redmine rocketchat mongo-rocket
+docker compose rm -s -f openldap keycloak db-keycloak next db-next db-redmine redmine rocketchat mongo-rocket
 podman unshare rm -rf data/ldap data/keycloak data/next data/rocket data/redmine data/bureau/settings.json
 mkdir -p data/ldap data/keycloak data/next data/rocket data/redmine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
           - db
 
   # Needs to install apps
-  # docker-compose exec -u www-data next ./occ app:install groupfolders
+  # docker compose exec -u www-data next ./occ app:install groupfolders
   # Also requires enabling access to nginx user
   # and also specifying the directory as good for the server to look inside
   # semanage fcontext -a -t httpd_sys_content_t "/srv/static/next(/.*)?"

--- a/launch.sh
+++ b/launch.sh
@@ -3,9 +3,9 @@
 INTRANET_REPO=https://github.com/EnterpriseyIntranet/intranet.git
 
 set -ex
-docker-compose up -d db-next
-docker-compose up -d mongo-rocket
-docker-compose up -d openldap
+docker compose up -d db-next
+docker compose up -d mongo-rocket
+docker compose up -d openldap
 sleep 15 &
 
 . "$(dirname "${BASH_SOURCE[0]}")/provision.sh"
@@ -13,9 +13,9 @@ configure_rocketchat
 
 (test -d build/teap || { cd build && git clone "$INTRANET_REPO"; } )
 (cd build/teap && git fetch origin && git pull)
-docker-compose build teap
+docker compose build teap
 wait
 
-docker-compose up -d rocketchat
-docker-compose up -d next
-docker-compose up -d teap
+docker compose up -d rocketchat
+docker compose up -d next
+docker compose up -d teap

--- a/provision.sh
+++ b/provision.sh
@@ -53,7 +53,7 @@ KEYCLOAK_SAML_ROOT=$KEYCLOAK_MASTER_ROOT/protocol/saml
 # Helper function, useful for connecting to postgres DBs right away
 # $1: db host stem
 function db_admin {
-	docker-compose exec "db-$1" bash -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
+	docker compose exec "db-$1" bash -c 'psql -U "$POSTGRES_USER" "$POSTGRES_DB"'
 }
 
 
@@ -78,8 +78,8 @@ function ldap_query {
 	filter="$1"
 	output_field="$2"
 	test -n "$3" && search_base_restriction="$3,"
-	docker-compose exec openldap ldapsearch -b "${search_base_restriction}$LDAP_BASE_DN" -x -w "$ADMIN_PASSWORD" -D "$ADMIN_DN" "$filter" "$output_field"
-	# docker-compose exec openldap bash -c "ldapsearch -b \"${search_base_restriction}\$LDAP_BASE_DN\" -x -w \"\$LDAP_ADMIN_PASSWORD\" -D \"cn=admin,\$LDAP_BASE_DN\" \"$filter\" \"$output_field\""
+	docker compose exec openldap ldapsearch -b "${search_base_restriction}$LDAP_BASE_DN" -x -w "$ADMIN_PASSWORD" -D "$ADMIN_DN" "$filter" "$output_field"
+	# docker compose exec openldap bash -c "ldapsearch -b \"${search_base_restriction}\$LDAP_BASE_DN\" -x -w \"\$LDAP_ADMIN_PASSWORD\" -D \"cn=admin,\$LDAP_BASE_DN\" \"$filter\" \"$output_field\""
 }
 
 
@@ -97,7 +97,7 @@ function ldap_extract {
 # $3: what to query
 # We use bash statement to let the container do the env var substitution
 function ldap_query_ou {
-	docker-compose exec openldap bash -c "ldapsearch -b \"ou=$1,\$LDAP_BASE_DN\" -x -w \"\$LDAP_ADMIN_PASSWORD\" -D \"$ADMIN_DN\" \"(cn=$2)\" \"$3\""
+	docker compose exec openldap bash -c "ldapsearch -b \"ou=$1,\$LDAP_BASE_DN\" -x -w \"\$LDAP_ADMIN_PASSWORD\" -D \"$ADMIN_DN\" \"(cn=$2)\" \"$3\""
 }
 
 
@@ -116,7 +116,7 @@ function change_mail_domain {
 # $2: old in days, default 90
 function search_for_old_trashed_mails {
 	local old=${2:-90}
-	docker-compose exec mail doveadm search -u "$1"  mailbox Trash savedbefore "${old}d"
+	docker compose exec mail doveadm search -u "$1"  mailbox Trash savedbefore "${old}d"
 }
 
 
@@ -124,13 +124,13 @@ function search_for_old_trashed_mails {
 # $2: old in days, default 90
 function delete_old_trashed_mails {
 	local old=${2:-90}
-	docker-compose exec mail doveadm expunge -u "$1" mailbox Trash savedbefore "${old}d"
+	docker compose exec mail doveadm expunge -u "$1" mailbox Trash savedbefore "${old}d"
 }
 
 
 # $1: Arguments to doveadm as one single string
 function doveadm_exec {
-	docker-compose exec mail bash -c "doveadm $1"
+	docker compose exec mail bash -c "doveadm $1"
 }
 
 
@@ -224,7 +224,7 @@ function settle_fs_ownership {
 	for pair in "${!FS_OWNERSHIP[@]}"; do
 		name=$(cut -f 1 -d , <<< $pair)
 		dir=$(cut -f 2 -d , <<< $pair)
-		docker-compose exec -u root $name chown -R ${FS_OWNERSHIP[$pair]} $dir
+		docker compose exec -u root $name chown -R ${FS_OWNERSHIP[$pair]} $dir
 	done
 }
 
@@ -407,7 +407,7 @@ MONGO_ACCOUNTS[RegistrationForm]='"Disabled"'
 
 
 function nextcloud_exec {
-	docker-compose exec --user www-data "$NEXTCLOUD_HOSTNAME" "$@"
+	docker compose exec --user www-data "$NEXTCLOUD_HOSTNAME" "$@"
 }
 
 
@@ -426,13 +426,13 @@ function nextcloud_exec_occ_set_ldap_indirect {
 
 
 function bureau_exec_flask {
-	docker-compose exec bureau flask "$@"
+	docker compose exec bureau flask "$@"
 }
 
 
 # Useful for indirect configuration using bash and env vars
 function keycloak_exec {
-	docker-compose exec keycloak "$@"
+	docker compose exec keycloak "$@"
 }
 
 
@@ -688,7 +688,7 @@ function generate_rsa_certs {
 
 
 function mongo_rocket_eval {
-	docker-compose exec mongo-rocket mongosh 'db/rocketchat' --eval "$1"
+	docker compose exec mongo-rocket mongosh 'db/rocketchat' --eval "$1"
 }
 
 
@@ -759,8 +759,8 @@ function backup_postgres_db {
 	name=$1
 	backupdir=$2
 	# POSTGRES_USER is known only *inside* of the container
-	# docker-compose exec $name bash -c 'pg_dumpall -c -U $POSTGRES_USER' > $backupdir/dump_${name}_`date +%Y-%m-%d"_"%H_%M_%S`.sql
-	docker-compose exec $name bash -c 'pg_dumpall -c -U $POSTGRES_USER' > $backupdir/dump_${name}.sql
+	# docker compose exec $name bash -c 'pg_dumpall -c -U $POSTGRES_USER' > $backupdir/dump_${name}_`date +%Y-%m-%d"_"%H_%M_%S`.sql
+	docker compose exec $name bash -c 'pg_dumpall -c -U $POSTGRES_USER' > $backupdir/dump_${name}.sql
 }
 
 
@@ -770,7 +770,7 @@ function backup_mongo_db {
 	local name backupdir
 	name=$1
 	backupdir=$2
-	docker-compose exec $name mongodump --archive > $backupdir/dump_${name}.archive
+	docker compose exec $name mongodump --archive > $backupdir/dump_${name}.archive
 }
 
 
@@ -784,7 +784,7 @@ function prune_mongo_db {
 
 # $1: Ldif as string
 function ldap_modify {
-	docker-compose exec -T openldap ldapmodify -Q -Y EXTERNAL -H ldapi:///
+	docker compose exec -T openldap ldapmodify -Q -Y EXTERNAL -H ldapi:///
 }
 
 

--- a/start.sh
+++ b/start.sh
@@ -7,33 +7,33 @@ export ADMIN_PASSWORD=none
 
 set -x
 
-docker-compose up -d openldap
-docker-compose up -d mongo-rocket
-docker-compose up -d db-next db-keycloak db-redmine
+docker compose up -d openldap
+docker compose up -d mongo-rocket
+docker compose up -d db-next db-keycloak db-redmine
 
-docker-compose up -d --wait mongo-rocket
+docker compose up -d --wait mongo-rocket
 
 configure_mongo
 
-docker-compose up -d next
+docker compose up -d next
 
-docker-compose up -d --wait db-keycloak
+docker compose up -d --wait db-keycloak
 
-docker-compose up -d keycloak
+docker compose up -d keycloak
 
 configure_ldap_acl
 
-docker-compose up -d --wait next
+docker compose up -d --wait next
 
 configure_nextcloud
 configure_nextcloud_ldap
 
-docker-compose up -d rocketchat
+docker compose up -d rocketchat
 
 configure_bureau_saml_except_certs
-docker-compose up -d bureau
+docker compose up -d bureau
 
-docker-compose up -d --wait keycloak
+docker compose up -d --wait keycloak
 
 configure_keycloak_next
 configure_keycloak_bureau
@@ -52,16 +52,16 @@ configure_nextcloud_saml_except_certs
 configure_nextcloud_saml_certs
 
 configure_redmine_saml
-docker-compose up -d redmine
+docker compose up -d redmine
 
-docker-compose up -d gateway
-docker-compose restart gateway
+docker compose up -d gateway
+docker compose restart gateway
 
 bureau_exec_flask bootstrap
 
-docker-compose restart bureau
+docker compose restart bureau
 
-docker-compose restart gateway
+docker compose restart gateway
 
 echo Now generate an invite link for an admin user of a username of your choice:
-echo 'docker-compose exec bureau flask invite-admin-user <username>'
+echo 'docker compose exec bureau flask invite-admin-user <username>'

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,17 +1,17 @@
-docker-compose stop next db-next
-docker-compose rm -f next db-next
+docker compose stop next db-next
+docker compose rm -f next db-next
 rm -rf data/next
 mkdir -p data/next
 
-docker-compose stop rocketchat mongo-rocket
-docker-compose rm -f rocketchat mongo-rocket
+docker compose stop rocketchat mongo-rocket
+docker compose rm -f rocketchat mongo-rocket
 rm -rf data/rocket
 mkdir -p data/rocket
 
-docker-compose stop openldap
-docker-compose rm -f openldap
+docker compose stop openldap
+docker compose rm -f openldap
 rm -rf data/ldap
 mkdir -p data/ldap
 
-docker-compose stop teap
-docker-compose rm -f teap
+docker compose stop teap
+docker compose rm -f teap


### PR DESCRIPTION
Since the version v2 of Docker Compose the command `docker compose` over `docker-compose` is used. We use some features of the later versions and that's why we should also use `docker compose`.