### PR TITLE
fix: correct bind mount target for data/bureau/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,30 @@ Namely:
 ## Project structure
 
 - Root folder:
-  - `start.sh`: Start respective containers.
-  - `provision.sh`: Define Bash functions that set those containers up.
-  - `cleanup_data.sh`: Discard those containers.
+  - `start.sh`: Starts respective containers.
+  - `provision.sh`: Defines Bash functions that set those containers up.
+  - `cleanup_data.sh`: Removes those containers and deletes content of their bind mounts.
 - `build` folder: Contains data needed for building of some of the container images.
 - `data` folder: Contains persistent data used by the respective containers. Actual data are not part of the repository.
 
 
 ## How to use
 
-Create a file .env based on .env.example, so the docker compose can populate variables from it.
+Make sure your `/etc/docker/daemon.json` contains:
+```
+{
+  "userns-remap": "default"
+}
+```
+
+Create a file `.env` based on `.env.example`, so Docker Compose can populate variables from it.
 You may have to define a bunch of DB-app passwords in there.
 The admin password can be also changed, but you will have to repeat the change in the `start.sh` file too, as both containers and provisioning scripts need to know it.
+
+Create a file `data/bureau/env` based on `data/bureau/env.example` and assign a string to the variable `SECRET_KEY`.
+
+Typical usage:
+```
+bash ./cleanup_data.sh
+bash ./start.sh
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,7 +293,7 @@ services:
 
       - SAML_PATH=/app/saml
     volumes:
-      - ./data/bureau/env:/app/.env:Z
+      - ./data/bureau/env:/app/bureau/.env:Z
       - ./data/bureau/ldap.ini:/app/ldap.ini:Z
       - ./data/bureau/settings.json:/app/saml/settings.json:Z
     security_opt:

--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,11 @@ export ADMIN_PASSWORD=none
 
 set -x
 
+jq --version > /dev/null || { echo "You need the jq utility"; exit 1; }
+test -f data/bureau/env || { echo "You need to create the data/bureau/env file by copying and modifying the env.example"; exit 1; }
+grep -q "^ADMIN_PASSWORD=$ADMIN_PASSWORD\$" .env || { echo "Inconsistent admin password between the .env file and the start environment"; exit 1; }
+grep -q "^DOMAINNAME=$DOMAINNAME\$" .env || { echo "Inconsistent domain name between the .env file and the start environment"; exit 1; }
+
 docker compose up -d openldap
 docker compose up -d mongo-rocket
 docker compose up -d db-next db-keycloak db-redmine


### PR DESCRIPTION
This PR fixes the failing admin user creation process of Bureau. 

Changes include:

- Correcting the target directory of the `data/bureau/env` bind mount.
- Adding instructions to create `data/bureau/env` to the README.
- Documenting typical usage of the `cleanup_data.sh` and `start.sh` scripts.
- Adding information about the `"userns-remap": "default"` setting, which is required for running `cleanup_data.sh`.