### PR TITLE
fix: replace podman unshare by sudo in data cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,23 @@ Namely:
 ## Project structure
 
 - Root folder:
-  - `start.sh`: Start respective containers.
-  - `provision.sh`: Define Bash functions that set those containers up.
-  - `cleanup_data.sh`: Discard those containers.
+  - `start.sh`: Starts respective containers.
+  - `provision.sh`: Defines Bash functions that set those containers up.
+  - `cleanup_data.sh`: Removes those containers and deletes content of their bind mounts.
 - `build` folder: Contains data needed for building of some of the container images.
 - `data` folder: Contains persistent data used by the respective containers. Actual data are not part of the repository.
 
 
 ## How to use
 
-Create a file .env based on .env.example, so the docker compose can populate variables from it.
+Create a file `.env` based on `.env.example`, so Docker Compose can populate variables from it.
 You may have to define a bunch of DB-app passwords in there.
 The admin password can be also changed, but you will have to repeat the change in the `start.sh` file too, as both containers and provisioning scripts need to know it.
+
+Create a file `data/bureau/env` based on `data/bureau/env.example` and assign a string to the variable `SECRET_KEY`.
+
+Typical usage:
+```
+bash ./cleanup_data.sh
+bash ./start.sh
+```

--- a/cleanup_data.sh
+++ b/cleanup_data.sh
@@ -1,3 +1,6 @@
+SCRIPT_DIR="$(dirname $0)"
+cd "$SCRIPT_DIR"
+
 docker compose rm -s -f openldap keycloak db-keycloak next db-next db-redmine redmine rocketchat mongo-rocket
-podman unshare rm -rf data/ldap data/keycloak data/next data/rocket data/redmine data/bureau/settings.json
+sudo rm -rf data/ldap data/keycloak data/next data/rocket data/redmine data/bureau/settings.json
 mkdir -p data/ldap data/keycloak data/next data/rocket data/redmine


### PR DESCRIPTION
`podman unshare rm ...` in `cleanup_data.sh` didn't work when containers were created by Docker due to permission differences. This PR replaces `podman unshare` with `sudo` and enhances documentation.